### PR TITLE
[s] mobile view button layout

### DIFF
--- a/views/home.html
+++ b/views/home.html
@@ -99,7 +99,7 @@ Welcome - Home
 
   <!-- Link to all news -->
   <section class="flex justify-center px-24">
-    <a class="text-center w-1/4 block px-3 py-2 hover:text-white hover:bg-secondary border border-secondary" href="/blog" aria-label="{{__('View all news')}}">
+    <a class="text-center w-48 block px-3 py-2 hover:text-white hover:bg-secondary border border-secondary" href="/blog" aria-label="{{__('View all news')}}">
       <span class="">{{__('View all news')}}</span>
     </a>
   </section>


### PR DESCRIPTION
I fixed mobile view button layout by changing `<a class="text-center w-1/4 block px-3 p...` to `<a class="text-center w-48 block px-3 p...`
Now mobile view looks as on the screenshot below:

![mobile-view-button](https://user-images.githubusercontent.com/12686547/70431664-cf566000-1a7d-11ea-828d-7fe397328e4f.png)
