### PR TITLE
[s] a large amont of whitespace between title and content

### DIFF
--- a/views/static.html
+++ b/views/static.html
@@ -27,7 +27,7 @@
 
   <main class="mb-gutter lg:mb-0 lg:w-2/3 lg:mr-gutter">
     <!-- featured image -->
-    <img class="w-full" src="{{ image }}" />
+    <img class="w-full h-0" src="{{ image }}" />
 
     <h1 class="text-4xl font-semibold">{{title}}</h1>
 


### PR DESCRIPTION
I fixed this white space by changing `<img class="w-full h"` to `<img class="w-full h-0"`
Now page view in IE11 looks as screenshot below:

![ie-white-space](https://user-images.githubusercontent.com/12686547/70432264-23ae0f80-1a7f-11ea-8631-8c018afe05b9.PNG)
