### PR TITLE
[update][m] t15 - pressing enter on search result should select dataset

### DIFF
--- a/views/base.html
+++ b/views/base.html
@@ -117,8 +117,8 @@
       <!-- Footer -->
       <footer class="site-footer bg-primary text-white-75 mt-10 py-gutter text-sm">
         <div class="container mx-auto md:flex md:justify-between">
-          <div class="px-gutter md:p-gutter md:w-1/3 md:flex flex-col justify-between" style="padding-bottom: 1.5rem">
-            <a class="block w-24 mb-0 text-white-75 hover:text-white" href="https://ckan.org/" style="height: 70px;">
+          <div class="px-gutter pb-6 md:p-gutter md:w-1/3 md:flex flex-col justify-between">
+            <a class="block w-24 mb-10 h-10 text-white-75 hover:text-white" href="https://ckan.org/">
               <span>Powered by</span>
               {% include "./partials/ckan-logo.svg" %}
             </a>
@@ -135,12 +135,12 @@
 
             <ul class="flex">
               <li>
-                <a target="_blank" href="https://www.linkedin.com/company/open-data-dk" class="site-footer_link"><svg viewbox="0 0 512 512" style="height: 40px; width: 40px;">
+                <a target="_blank" href="https://www.linkedin.com/company/open-data-dk" class="site-footer_link"><svg class="h-10 w-10" viewbox="0 0 512 512">
                <path d="M186.4 142.4c0 19-15.3 34.5-34.2 34.5 -18.9 0-34.2-15.4-34.2-34.5 0-19 15.3-34.5 34.2-34.5C171.1 107.9 186.4 123.4 186.4 142.4zM181.4 201.3h-57.8V388.1h57.8V201.3zM273.8 201.3h-55.4V388.1h55.4c0 0 0-69.3 0-98 0-26.3 12.1-41.9 35.2-41.9 21.3 0 31.5 15 31.5 41.9 0 26.9 0 98 0 98h57.5c0 0 0-68.2 0-118.3 0-50-28.3-74.2-68-74.2 -39.6 0-56.3 30.9-56.3 30.9v-25.2H273.8z"></path>
               </svg></a>
               </li>
               <li>
-                <a target="_blank" href="https://twitter.com/OpenDataDK" class="site-footer_link"> <svg viewbox="0 0 512 512" style="height: 40px; width: 40px;">
+                <a target="_blank" href="https://twitter.com/OpenDataDK" class="site-footer_link"> <svg class="h-10 w-10" viewbox="0 0 512 512">
                <path d="M419.6 168.6c-11.7 5.2-24.2 8.7-37.4 10.2 13.4-8.1 23.8-20.8 28.6-36 -12.6 7.5-26.5 12.9-41.3 15.8 -11.9-12.6-28.8-20.6-47.5-20.6 -42 0-72.9 39.2-63.4 79.9 -54.1-2.7-102.1-28.6-134.2-68 -17 29.2-8.8 67.5 20.1 86.9 -10.7-0.3-20.7-3.3-29.5-8.1 -0.7 30.2 20.9 58.4 52.2 64.6 -9.2 2.5-19.2 3.1-29.4 1.1 8.3 25.9 32.3 44.7 60.8 45.2 -27.4 21.4-61.8 31-96.4 27 28.8 18.5 63 29.2 99.8 29.2 120.8 0 189.1-102.1 185-193.6C399.9 193.1 410.9 181.7 419.6 168.6z"></path>
                </svg></a>
               </li>
@@ -222,28 +222,42 @@
       });
 
       $(".searchInput").on('keyup', function (event) {
-        let homeSeachFlag = $(this).attr('id').includes("Home") ? "Home" : "";
+	if (event.originalEvent.code === "Escape") {
+	  let homeSeachFlag = $(this).attr('id').includes("Home") ? "Home" : "";
 
-        let searchSelect = $("#searchSelect" + homeSeachFlag);
-        let searchSelect1 = $("#searchSelect1" + homeSeachFlag);
-        let searchSelect2 = $("#searchSelect2" + homeSeachFlag);
+          let searchSelect = $("#searchSelect" + homeSeachFlag);
+          let searchSelect1 = $("#searchSelect1" + homeSeachFlag);
+          let searchSelect2 = $("#searchSelect2" + homeSeachFlag);
 
-        searchSelect1.val($(this).val());
-        searchSelect2.val($(this).val());
+	  searchSelect.css('display','none');
 
-        if ($(this).val() !== "") {
-          searchSelect.css('display','block');
-        } else {
-          searchSelect.css('display','none');
-        }
+	} else {
+          let homeSeachFlag = $(this).attr('id').includes("Home") ? "Home" : "";
 
-        if (event.originalEvent.code === "ArrowUp") {
-          $(this).blur();
-          searchSelect2.focus();
-        } else if (event.originalEvent.code === "ArrowDown") {
-          $(this).blur();
-          searchSelect1.focus();
-        }
+          let searchSelect = $("#searchSelect" + homeSeachFlag);
+          let searchSelect1 = $("#searchSelect1" + homeSeachFlag);
+          let searchSelect2 = $("#searchSelect2" + homeSeachFlag);
+
+          searchSelect1.val($(this).val());
+          searchSelect2.val($(this).val());
+	
+	  if ($(this).val() !== "") {
+            searchSelect.css('display','block');
+          } else {
+            searchSelect.css('display','none');
+          }
+
+          if (event.originalEvent.code === "ArrowUp") {
+            $(this).blur();
+            searchSelect2.focus();
+          } else if (event.originalEvent.code === "ArrowDown") {
+            $(this).blur();
+            searchSelect1.focus();	  
+          } else if (event.originalEvent.code === "Enter") {
+            $(this).blur();
+            searchSelect1.focus();
+          }
+	}
       });
 
       $(".searchSelect1").on('keyup', function (event) {
@@ -257,8 +271,11 @@
           searchInput.focus();
         } else if (event.originalEvent.code === "ArrowDown") {
           searchSelect2.focus();
-        } else if (event.originalEvent.code.includes("Enter")) {
+        } else if (event.originalEvent.code === ("Enter")) {
           selectedInput1($(this).val());
+        } else if (event.originalEvent.code === ("Escape")) {
+	  searchInput.focus();
+          searchSelect.css('display','none');
         } else {
           searchInput.val(searchInput.val() + event.key).focus();
         }
@@ -277,6 +294,9 @@
           searchInput.focus();
         } else if (event.originalEvent.code.includes("Enter")) {
           selectedInput2($(this).val());
+        } else if (event.originalEvent.code.includes("Escape")) {
+          searchInput.focus();
+          searchSelect.css('display','none');
         } else {
           searchInput.val(searchInput.val() + event.key).focus();
         }


### PR DESCRIPTION
According to the client's requirements, I have changed the behavior of the `Search box` in relation to the use of the `Enter` command from the keyboard. Now, the first press of `Enter` selects `Search datasets` and the second press executes a `Search datasets`.
I also changed the behavior of the `Search box` by pressing the `Escape` command on the keyboard. Earlier in the search box `Escape` was printed in the extension of the search term, and now the first press of `Esc` returns the focus to the first item in `search box list`, and the second closes the `search box list`. Similar to `Cancel` command.
![escape_bottom](https://user-images.githubusercontent.com/12686547/70991265-672ffb80-20c7-11ea-82fd-ddea459caafa.png)
![escape_top](https://user-images.githubusercontent.com/12686547/70991266-672ffb80-20c7-11ea-9614-3685b5653639.png)

