### PR TITLE
[xs] t6 - new text for search boxes

### DIFF
--- a/i18n/da.json
+++ b/i18n/da.json
@@ -10,8 +10,8 @@
 	"about": "Om",
 	"Search": "Søg",
 	"Search ...": "Søg ...",
-	"Search Datasets": "Søg datasæt",
-	"Search datasets": "Søg datasæt",
+	"Search Datasets": "Søg i datasæt",
+	"Search datasets": "Søg i datasæt",
 	"Events": "Begivenheder",
 	"Follow us": "Følg os",
 	"Recently Added or updated datasets": "For nylig tilføjede eller opdaterede datasæt",
@@ -48,7 +48,7 @@
 	"Conflict": "Conflict",
 	"knowledge": "Viden om",
 	"hvad-er-open-data-dk": "hvad-er-open-data-dk",
-	"Search website": "Søg på websted",
+	"Search website": "Søg på hjemmeside",
 	"Datasets": "Datasæt",
 	"Groups": "Grupper",
 	"Internationale spørgsmål": "Internationale spørgsmål",
@@ -71,5 +71,9 @@
 	"Her er en oversigt over de kommuner, regioner og andre organisationer, der udstiller data på Open Data DK portalen. Under hver organisation kan du finde alle de datasæt, organisationen udstiller.": "Her er en oversigt over de kommuner, regioner og andre organisationer, der udstiller data på Open Data DK portalen. Under hver organisation kan du finde alle de datasæt, organisationen udstiller.",
 	"Som dataejer i en organisation kan du oprette, redigere og publicere data afhængigt af din autorisation. Dette foregår via administrationsmodulet. Hvis I er medlem af Open Data DK, har I modtaget et link til administrationsmodulet.": "Som dataejer i en organisation kan du oprette, redigere og publicere data afhængigt af din autorisation. Dette foregår via administrationsmodulet. Hvis I er medlem af Open Data DK, har I modtaget et link til administrationsmodulet.",
 	"Dataejere har ikke mulighed for selv at kategorisere datasæt. Du er derimod velkommen til at kontakte <a href=\"mailto:info@opendata.dk\">info@opendata.dk</a> med forslag til kategorisering af dine datasæt i de eksisterende grupper.": "Dataejere har ikke mulighed for selv at kategorisere datasæt. Du er derimod velkommen til at kontakte <a href=\"mailto:info@opendata.dk\">info@opendata.dk</a> med forslag til kategorisering af dine datasæt i de eksisterende grupper.",
-	"Preview": "Preview"
+	"Preview": "Preview",
+	"Indholdet er for stort til at blive vist.": "Content is too large to be previewed.",
+	"Download dataene.": "Download the data.",
+	"Datavisning ikke tilgængelig.": "Data view unavailable.",
+	"Keywords": "Keywords"
 }


### PR DESCRIPTION
Changed two translations in da.json related to `Search box` list values
* Before:
![search_before](https://user-images.githubusercontent.com/12686547/70993738-e96eee80-20cc-11ea-960c-150e09b9ae54.png)

* After:
![search_bottom_after](https://user-images.githubusercontent.com/12686547/70993742-e96eee80-20cc-11ea-972d-3fbd8810c5aa.png)
![search_top_after](https://user-images.githubusercontent.com/12686547/70993743-ea078500-20cc-11ea-9058-995c4dd2f1a2.png)

