### PR TITLE
IE - a lot whitespace between title and content

### DIFF
--- a/views/static.html
+++ b/views/static.html
@@ -27,8 +27,9 @@
 
   <main class="mb-gutter lg:mb-0 lg:w-2/3 lg:mr-gutter">
     <!-- featured image -->
+    {% if image %}
     <img class="w-full" src="{{ image }}" />
-
+    {% endif %}
     <h1 class="text-4xl font-semibold">{{title}}</h1>
 
     <div class="content">


### PR DESCRIPTION
IE showing a lot of white space between title an content because there is no image. I added a condition to check, then show image if it exists.
![ie-white-space](https://user-images.githubusercontent.com/12686547/71128324-45c92f80-21ed-11ea-8f51-3d54be1c21b0.PNG)
