### PR TITLE
t8-classification-fills-search-field

### DIFF
--- a/views/partials/data-search-form.njk
+++ b/views/partials/data-search-form.njk
@@ -1,7 +1,7 @@
 <!-- Form -->
 <form action="/search" method="GET">
   <div class="relative mb-10">
-    <input type="text" class="border-2 border-solid border-gray-200 py-4 pl-4 pr-20 text-xl outline-none focus:border-secondary w-full" placeholder="{{__('Search datasets')}}" name="q" value="{{ query.q }}" autofocus>
+    <input type="text" class="border-2 border-solid border-gray-200 py-4 pl-4 pr-20 text-xl outline-none focus:border-secondary w-full" placeholder="{{__('Search datasets')}}" name="q" autofocus>
 
     <button class="absolute inset-y-0 right-0 w-16 px-4 text-secondary fill-current" type="submit" aria-label="Submit">
       <svg class="w-full h-full"><use xlink:href="#search" /></svg>


### PR DESCRIPTION
Client wants that classifications not to  fill search field. Changes are made on file `data-search-form.njk`

Before changes:
![search_fill_before](https://user-images.githubusercontent.com/12686547/71128911-a016c000-21ee-11ea-9ccf-82a3dfab1fb8.png)

After changes:
![search_fill_after](https://user-images.githubusercontent.com/12686547/71128910-a016c000-21ee-11ea-97e7-05490a491bdb.png)
