### PR TITLE
[bugfix] duplicated filters in query string

### DIFF
--- a/views/partials/search-filter.njk
+++ b/views/partials/search-filter.njk
@@ -11,12 +11,30 @@
   <h2 class="bg-gray-200 px-4 py-3 border-t border-gray-200 font-bold">{{ facetNames[facetId] }}</h2>
   <ul>
     {% for item in value.items|sort(true, false, 'count') %}
+    {% if query.q %}
+    {% if item.name in query.q %}
+    <li class="border-t border-gray-200">
+      <a href="/search?q={{ query.q }}" class="filter-button hover:text-secondary" aria-label="{{ item.display_name }} ({{ item.count }} results)">
+        {{ item.display_name }}
+        <span class="filter-button_count">{{ item.count }}</span>
+      </a>
+    </li>
+    {% else %}
     <li class="border-t border-gray-200">
       <a href="/search?q={{ facetId }}:{{ item.name }} {{ query.q }}" class="filter-button hover:text-secondary" aria-label="{{ item.display_name }} ({{ item.count }} results)">
         {{ item.display_name }}
         <span class="filter-button_count">{{ item.count }}</span>
       </a>
     </li>
+    {% endif %}
+    {% else %}
+    <li class="border-t border-gray-200">
+      <a href="/search?q={{ facetId }}:{{ item.name }} {{ query.q }}" class="filter-button hover:text-secondary" aria-label="{{ item.display_name }} ({{ item.count }} results)">
+        {{ item.display_name }}
+        <span class="filter-button_count">{{ item.count }}</span>
+      </a>
+    </li>
+    {% endif %}
     {% endfor %}
     {# Link for showing more items from this face #}
     {% if value.items | length > 4 %}


### PR DESCRIPTION
This fix a bug with showing duplicated values of filter in query string when user clicks on same filter two or more times. The problem is not only visual, but if the user wants to change the value of the filter, they must delete multiple parts of the query string beforehand. Also, if [PR is accepted for not displaying the query string](https://github.com/datopian/frontend-oddk/pull/15) in the `input` field, then no filter badges 
duplicates will be displayed.

![filters_new](https://user-images.githubusercontent.com/12686547/72224400-89a81e00-357a-11ea-9f24-f4c3e8012286.png)

This bug fix may not be included in the current delivery, but it may be included at some later ones because it is completely independent of other changes.