### PR TITLE
[banner][s]: updates promo banner layout and text

### DIFF
--- a/i18n/da.json
+++ b/i18n/da.json
@@ -85,5 +85,6 @@
 	"Request data": "Efterspørg data",
 	"Påvirk udviklingen af Open Data DK & vind en sensor": "Påvirk udviklingen af Open Data DK & vind en sensor",
 	"Page found: favicon.ico": "Page found: favicon.ico",
-	"TÆT": "TÆT"
+	"Giv feedback": "Giv feedback",
+	"til udviklingen af Open Data DK og vind en sensor": "til udviklingen af Open Data DK og vind en sensor"
 }

--- a/views/partials/promo-banners/influence-development.njk
+++ b/views/partials/promo-banners/influence-development.njk
@@ -2,17 +2,20 @@
 {#  <button id="promo-banner-thumbnail" class="">UNDERSØGELSE</button>#}
   <div
       id="promo-banner"
-      class="flex flex-col lg:flex-row content-center bg-repeat bg-left-top p-2 lg:p-6"
-      style="background-image: url(/static/img/promo-banner-bg.png); background-size: auto 6em;">
-    <a class="max-w-full mx-auto px-6 py-1 text-2xl font-bold bg-white rounded border-2 border-red-200 text-primary hover:text-secondary flex content-center"
+      class="flex flex-row content-center bg-repeat bg-left-top p-2 lg:p-5"
+      style="background-image: url(/static/img/promo-banner-bg.png); background-size: auto 5.75em;">
+    <a class="max-w-full flex flex-col lg:flex-row mx-auto px-6 py-1 text-2xl font-bold bg-white border-solid border-4 border-secondary text-primary hover:text-secondary flex content-center"
        target="_blank"
        href="https://www.survey-xact.dk/LinkCollector?key=6D46XF46SK35">
-      {{ __('Påvirk udviklingen af Open Data DK & vind en sensor') }}
+      <div class="underline whitespace-no-wrap">{{ __('Giv feedback') }}&nbsp;</div>
+      <div>{{ __('til udviklingen af Open Data DK og vind en sensor') }}</div>
     </a>
     <button
         id="promo-banner-close-button"
-        class="bg-white border-2 border-red-200 w-24 my-2 lg:my-auto mx-auto lg:mx-0 px-6 text-2xl rounded-full focus:bg-red-200 focus:text-white focus:outline-none"
-    >{{ __('TÆT') }}</button>
+        class="bg-white mb-auto lg:mx-0 px-3 text-2xl focus:bg-red-200 focus:text-white focus:outline-none"
+    >
+      <svg class="w-4 h-4 inline fill-current text-primary"><use xlink:href="#cross" /></svg>
+    </button>
     <script src="/static/js/js.cookie.min.js"></script>
     <script>
 


### PR DESCRIPTION
Screenshots of different screen sizes

<img width="1440" alt="Screen Shot 2020-08-12 at 8 54 11 PM" src="https://user-images.githubusercontent.com/27793901/90023972-90e50500-dcde-11ea-9293-537f80dfd6ba.png">

---

<img width="889" alt="Screen Shot 2020-08-12 at 8 54 28 PM" src="https://user-images.githubusercontent.com/27793901/90023995-993d4000-dcde-11ea-9d2d-4051a78164a2.png">

---

<img width="486" alt="Screen Shot 2020-08-12 at 8 54 40 PM" src="https://user-images.githubusercontent.com/27793901/90024015-9e01f400-dcde-11ea-83f3-6ff6b3a5ab0c.png">
