### PR TITLE
[cookie][s]: adds policy.app.cookieinformation.com script

### DIFF
--- a/views/base.html
+++ b/views/base.html
@@ -20,6 +20,8 @@
       <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.3/leaflet.css">
     {% endif %}
     {% block styles %}{% endblock %}
+    <script id="CookieConsent" src="https://policy.app.cookieinformation.com/uc.js"
+             data-culture="DA" type="text/javascript"></script>
     <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
   </head>
   <body class="{% block bodyclass %}{{bodyclass}}{% endblock %}">


### PR DESCRIPTION
Note: doesn't work out of the box locally as it tries to load additional resources https://policy.app.cookieinformation.com/15be66/192.168.0.101/da.js (192.168.0.101 is the site address on local network, which should be replaced with `www.opendata.dk` on production)