### PR TITLE
[accessibility][l]: Adds hyperlink underlining and label/alt tags for…

### DIFF
--- a/public/js/twitterFetcher_min.js
+++ b/public/js/twitterFetcher_min.js
@@ -56,10 +56,10 @@ op+='<p class="tweet">'+strip(tweets[n].innerHTML)+'</p>';if(printTime){if(perma
 times[n].getAttribute('aria-label')+'</p>';}}}else{if(tweets[n].textContent){if(printUser){op+='<p class="user">'+authors[n].textContent+'</p>';}
 op+='<p class="tweet">'+tweets[n].textContent+'</p>';if(printTime){op+='<p class="timePosted">'+times[n].textContent+'</p>';}}else{if(printUser){op+='<p class="user">'+authors[n].textContent+'</p>';}
 op+='<p class="tweet">'+tweets[n].textContent+'</p>';if(printTime){op+='<p class="timePosted">'+times[n].textContent+'</p>';}}}
-if(showInteractionLinks){op+='<p class="interact"><a href="https://twitter.com/intent/'+'tweet?in_reply_to='+tids[n]+'" class="twitter_reply_icon"'+
-(targetBlank?' target="_blank" rel="noopener">':'>')+'Reply</a><a href="https://twitter.com/intent/retweet?'+'tweet_id='+tids[n]+'" class="twitter_retweet_icon"'+
+if(showInteractionLinks){op+='<p class="interact"><a href="https://twitter.com/intent/'+'tweet?in_reply_to='+tids[n]+'" class="twitter_reply_icon" title="Reply to '+tweets[n].textContent+' on Twitter"'+
+(targetBlank?' target="_blank" rel="noopener">':'>')+'Reply</a><a href="https://twitter.com/intent/retweet?'+'tweet_id='+tids[n]+'" class="twitter_retweet_icon" title="Retweet '+tweets[n].textContent+' on Twitter" + tweets[n].innerHTML'+
 (targetBlank?' target="_blank" rel="noopener">':'>')+'Retweet</a>'+'<a href="https://twitter.com/intent/favorite?tweet_id='+
-tids[n]+'" class="twitter_fav_icon"'+
+tids[n]+'" class="twitter_fav_icon" title="Favorite '+tweets[n].textContent+' on Twitter"'+
 (targetBlank?' target="_blank" rel="noopener">':'>')+'Favorite</a></p>';}
 if(showImages&&images[n]!==undefined&&extractImagesUrl(images[n])!==undefined){var extractedImages=extractImagesUrl(images[n]);for(var i=0;i<extractedImages.length;i++){op+='<div class="media">'+'<img src="'+extractedImages[i]+'" alt="Image from tweet" />'+'</div>';}}
 if(showImages){arrayTweets.push(op);}else if(!showImages&&tweets[n].textContent.length){arrayTweets.push(op);}

--- a/views/base.html
+++ b/views/base.html
@@ -82,10 +82,10 @@
                     <svg class="main-nav_search-toggle-icon w-8 h-6 hover:fill-secondary outline-none" data-toggle="hide"><use xlink:href="#cross" /></svg>
                   </a>
                   <div class="main-nav_search w-full px-6 py-2 lg:p-0 lg:absolute lg:left-0 lg:right-0 lg:pr-12 lg:pointer-events-none" id="header-search">
-<!--                    <input id="searchInput" name="q" type="text" class="searchInput border-2 border-solid px-3 py-2 lg:px-4 lg:py-3 lg:text-xl outline-none border-secondary w-full pointer-events-auto" placeholder="Søg datasæt">-->
+<!--                    <input id="searchInput" aria-label="{{__('Search')}}" name="q" type="text" class="searchInput border-2 border-solid px-3 py-2 lg:px-4 lg:py-3 lg:text-xl outline-none border-secondary w-full pointer-events-auto" placeholder="Søg datasæt">-->
                     <div class="dropdown">
                       <div class="relative">
-                        <input id="searchInput" autocomplete="off" type="text" class="searchInput border-2 border-solid px-3 py-2 lg:px-4 lg:py-3 lg:text-xl outline-none border-secondary w-full pointer-events-auto" placeholder="{{__('Search ...')}}" name="q" required />
+                        <input id="searchInput" aria-label="{{__('Search')}}" autocomplete="off" type="text" class="searchInput border-2 border-solid px-3 py-2 lg:px-4 lg:py-3 lg:text-xl outline-none border-secondary w-full pointer-events-auto" placeholder="{{__('Search ...')}}" name="q" required />
                         <button class="absolute inset-y-0 right-0 px-3 outline-none" type="submit">
                           <svg class="w-6 h-6 fill-white" aria-label="Search Datasets"><use xlink:href="#search" /></svg>
                         </button>
@@ -93,7 +93,7 @@
 
                       <div id="searchSelect" class="searchSelect">
                         <div id="searchSelect1Div" class="searchSelect1Div relative">
-                          <input id="searchSelect1" readonly type="text" class="searchSelect1 cursor-pointer hover:bg-secondary focus:bg-secondary border-2 border-solid pl-10 pr-48 py-3 lg:text-xl border-secondary w-full pointer-events-auto" />
+                          <input id="searchSelect1" aria-label="{{__('Search select 1')}}" readonly type="text" class="searchSelect1 cursor-pointer hover:bg-secondary focus:bg-secondary border-2 border-solid pl-10 pr-48 py-3 lg:text-xl border-secondary w-full pointer-events-auto" />
                           <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center px-2 text-gray-700">
                             <svg class="w-6 h-6 fill-primary" aria-label="Search Datasets"><use xlink:href="#search" /></svg>
                           </div>
@@ -105,7 +105,7 @@
                         </div>
 
                         <div id="searchSelect2Div" class="searchSelect2Div relative">
-                          <input id="searchSelect2" readonly type="text" class="searchSelect2 cursor-pointer hover:bg-secondary focus:bg-secondary border-2 border-solid pl-10 pr-48 py-3 lg:text-xl border-secondary w-full pointer-events-auto" />
+                          <input id="searchSelect2" aria-label="{{__('Search select 2')}}" readonly type="text" class="searchSelect2 cursor-pointer hover:bg-secondary focus:bg-secondary border-2 border-solid pl-10 pr-48 py-3 lg:text-xl border-secondary w-full pointer-events-auto" />
                           <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center px-2 text-gray-700">
                             <svg class="w-6 h-6 fill-primary" aria-label="Search content"><use xlink:href="#search" /></svg>
                           </div>

--- a/views/blog.html
+++ b/views/blog.html
@@ -30,7 +30,7 @@
     {% endif %}
     <div class="{{cls}}">
       <a class="article-preview_image" href="/blog/{{post.slug}}">
-        <img class="article-preview_img" alt="{{ post.imageCaption or post.imageAlt or post.title }}" src="{{post.image or '/static/img/placeholder.svg'}}" />
+        <img class="article-preview_img" alt="{{ post.imageAlt or post.title or post.imageCaption }}" src="{{post.image or '/static/img/placeholder.svg'}}" />
       </a>
       <div class="article-preview_text">
         <h1 class="article-preview_heading">

--- a/views/blog.html
+++ b/views/blog.html
@@ -30,7 +30,7 @@
     {% endif %}
     <div class="{{cls}}">
       <a class="article-preview_image" href="/blog/{{post.slug}}">
-        <img class="article-preview_img" alt="{{ post.alt or post.title }}" src="{{post.image or '/static/img/placeholder.svg'}}" />
+        <img class="article-preview_img" alt="{{ post.imageCaption or post.imageAlt or post.title }}" src="{{post.image or '/static/img/placeholder.svg'}}" />
       </a>
       <div class="article-preview_text">
         <h1 class="article-preview_heading">

--- a/views/blog.html
+++ b/views/blog.html
@@ -9,7 +9,7 @@
   <nav class="breadcrumb" aria-label="breadcrumb">
     <ol>
       <li class="breadcrumb_item">
-        <a class="breadcrumb_link" href="/">{{__('Home')}}</a>
+        <a class="breadcrumb_link hover:underline" href="/">{{__('Home')}}</a>
       </li>
       <li class="breadcrumb_item">
         <a class="breadcrumb_link" href="/blog" aria-current="page">{{__('Blog')}}</a>
@@ -30,11 +30,11 @@
     {% endif %}
     <div class="{{cls}}">
       <a class="article-preview_image" href="/blog/{{post.slug}}">
-        <img class="article-preview_img" src="{{post.image or '/static/img/placeholder.svg'}}" />
+        <img class="article-preview_img" alt="{{ post.alt or post.title }}" src="{{post.image or '/static/img/placeholder.svg'}}" />
       </a>
       <div class="article-preview_text">
         <h1 class="article-preview_heading">
-          <a class="article-preview_heading-link" href="/blog/{{post.slug}}">{{post.title | safe}}</a>
+          <a class="article-preview_heading-link hover:underline" href="/blog/{{post.slug}}">{{post.title | safe}}</a>
         </h1>
         <div class="mb-3">
           <ul>

--- a/views/collection.html
+++ b/views/collection.html
@@ -13,10 +13,10 @@
   <nav class="breadcrumb" aria-label="breadcrumb">
     <ol>
       <li class="breadcrumb_item">
-        <a class="breadcrumb_link" href="/">{{__('Home')}}</a>
+        <a class="breadcrumb_link hover:underline" href="/">{{__('Home')}}</a>
       </li>
       <li class="breadcrumb_item">
-        <a class="breadcrumb_link" href="/collections">{{__('Collections')}}</a>
+        <a class="breadcrumb_link hover:underline" href="/collections">{{__('Collections')}}</a>
       </li>
       <li class="breadcrumb_item">
         <a class="breadcrumb_link" href="/collections/{{ item.name }}" aria-current="page">{{ item.name }}</a>

--- a/views/collections-home.html
+++ b/views/collections-home.html
@@ -10,7 +10,7 @@
   <nav class="breadcrumb" aria-label="breadcrumb">
     <ol>
       <li class="breadcrumb_item">
-        <a class="breadcrumb_link" href="/">{{__('Home')}}</a>
+        <a class="breadcrumb_link hover:underline" href="/">{{__('Home')}}</a>
       </li>
       <li class="breadcrumb_item">
         <a class="breadcrumb_link" href="/{{ slug }}" aria-current="page">{{ __(title) }}</a>
@@ -39,10 +39,10 @@
     <li class="sm:w-1/2 lg:w-1/3">
       <a class="flex bg-gray-200 p-4 text-primary my-4 sm:mx-4" href="/{{ slug }}/{{ collection.name }}">
         <div class="w-24 h-24 mr-4 p-4 flex-shrink-0 flex justify-center {%if slug == 'organization' %}bg-white{% else %}bg-secondary{% endif %}">
-          <img class="w-full object-contain" src="{{ collection.image }}">
+          <img class="w-full object-contain" alt="{{ collection.title }}" src="{{ collection.image }}">
         </div>
         <div class="flex flex-col justify-center overflow-hidden">
-          <h2 class="font-semibold text-lg">{{ collection.title }}</h2>
+          <h2 class="font-semibold text-lg hover:underline">{{ collection.title }}</h2>
           <p>{{ collection.summary | safe | truncate(120) }}</p>
         </div>
       </a>

--- a/views/home.html
+++ b/views/home.html
@@ -70,7 +70,7 @@ Welcome - Home
     <!-- article-preview -->
     <article class="article-preview my-gutter pb-gutter md:w-1/3 md:mx-gutter">
       <a class="article-preview_image" href="/blog/{{post.slug}}">
-        <img class="article-preview_img" alt="{{ post.imageCaption or post.imageAlt or post.title }}" src="{{post.image or '/static/img/placeholder.svg'}}" />
+        <img class="article-preview_img" alt="{{ post.imageAlt or post.title or post.imageCaption }}" src="{{post.image or '/static/img/placeholder.svg'}}" />
       </a>
       <div class="article-preview_text">
         <h1 class="article-preview_heading">

--- a/views/home.html
+++ b/views/home.html
@@ -23,7 +23,7 @@ Welcome - Home
                 <span class="featured-groups_icon">
                   <img src="{{ collection.image }}" class="featured-groups_img" />
                 </span>
-                <span class="featured-groups_name">{{ collection.title }}</span>
+                <span class="featured-groups_name hover:underline">{{ collection.title }}</span>
               </a>
             </li>
           {% endfor %}
@@ -31,7 +31,7 @@ Welcome - Home
       <!-- searchbox -->
         <div class="dropdown">
           <div class="relative">
-            <input id="searchInputHome" autocomplete="off" type="text" class="searchInput bg-secondary pl-4 pr-12 py-3 text-lg text-white w-full outline-none" placeholder="{{__('Search ...')}}" name="q" required />
+            <input id="searchInputHome" aria-label="{{__('Search')}}" autocomplete="off" type="text" class="searchInput bg-secondary pl-4 pr-12 py-3 text-lg text-white w-full outline-none" placeholder="{{__('Search ...')}}" name="q" required />
             <button class="absolute inset-y-0 right-0 px-3 outline-none" type="submit">
               <svg class="w-6 h-6 fill-white" aria-label="Search Datasets"><use xlink:href="#search" /></svg>
             </button>
@@ -70,11 +70,11 @@ Welcome - Home
     <!-- article-preview -->
     <article class="article-preview my-gutter pb-gutter md:w-1/3 md:mx-gutter">
       <a class="article-preview_image" href="/blog/{{post.slug}}">
-        <img class="article-preview_img" src="{{post.image or '/static/img/placeholder.svg'}}" />
+        <img class="article-preview_img" alt="{{ post.caption or post.title }}" src="{{post.image or '/static/img/placeholder.svg'}}" />
       </a>
       <div class="article-preview_text">
         <h1 class="article-preview_heading">
-          <a class="article-preview_heading-link" href="/blog/{{post.slug}}">{{ post.title | safe }}</a>
+          <a class="article-preview_heading-link hover:underline" href="/blog/{{post.slug}}">{{ post.title | safe }}</a>
         </h1>
         <div class="mb-3">
           <ul>
@@ -116,7 +116,7 @@ Welcome - Home
               <span class="font-semibold text-3xl leading-none">{{ event.day }}</span> <span class="leading-none">{{ event.month }}</span>
             </time>
             <div class="px-6">
-              <h3 class="font-semibold text-2xl text-primary">{{ event.title | safe }}</h3>
+              <h3 class="font-semibold text-2xl text-primary hover:underline">{{ event.title | safe }}</h3>
               <p>
                 {{ event.excerpt | striptags | safe | truncate(120) or event.content | striptags | safe | truncate(120) }}
               </p>
@@ -137,7 +137,7 @@ Welcome - Home
       <p class="leading-relaxed">
         {{ aboutText | safe | truncate(300) }}
       </p>
-      <a class="font-semibold text-white" href="/about">{{__('More')}}</a>
+      <a class="font-semibold text-white hover:underline" href="/about">{{__('More')}}</a>
     </li>
     </div>
     <div id="tweets" class="twitter-feed"></div>

--- a/views/home.html
+++ b/views/home.html
@@ -70,7 +70,7 @@ Welcome - Home
     <!-- article-preview -->
     <article class="article-preview my-gutter pb-gutter md:w-1/3 md:mx-gutter">
       <a class="article-preview_image" href="/blog/{{post.slug}}">
-        <img class="article-preview_img" alt="{{ post.caption or post.title }}" src="{{post.image or '/static/img/placeholder.svg'}}" />
+        <img class="article-preview_img" alt="{{ post.imageCaption or post.imageAlt or post.title }}" src="{{post.image or '/static/img/placeholder.svg'}}" />
       </a>
       <div class="article-preview_text">
         <h1 class="article-preview_heading">

--- a/views/owner.html
+++ b/views/owner.html
@@ -12,10 +12,10 @@
   <nav class="breadcrumb" aria-label="breadcrumb">
     <ol>
       <li class="breadcrumb_item">
-        <a class="breadcrumb_link" href="/">{{__('Home')}}</a>
+        <a class="breadcrumb_link hover:underline" href="/">{{__('Home')}}</a>
       </li>
       <li class="breadcrumb_item">
-        <a class="breadcrumb_link" href="/organization">{{__('Organizations')}}</a>
+        <a class="breadcrumb_link hover:underline" href="/organization">{{__('Organizations')}}</a>
       </li>
       <li class="breadcrumb_item">
         <a class="breadcrumb_link" href="/{{owner.name}}" aria-current="page">{{ owner.title }}</a>

--- a/views/partials/data-search-form.njk
+++ b/views/partials/data-search-form.njk
@@ -1,7 +1,7 @@
 <!-- Form -->
 <form action="/search" method="GET">
   <div class="relative mb-5">
-    <input id="search-input" type="text" class="border-2 border-solid border-gray-200 py-4 pl-4 pr-20 text-xl outline-none focus:border-secondary w-full" placeholder="{{__('Search datasets')}}" name="q" value="" autofocus>
+    <input id="search-input" aria-label="{{__('Search datasets')}}" type="text" class="border-2 border-solid border-gray-200 py-4 pl-4 pr-20 text-xl outline-none focus:border-secondary w-full" placeholder="{{__('Search datasets')}}" name="q" value="" autofocus>
       <button id="search-button" class="absolute inset-y-0 right-0 w-16 px-4 text-secondary fill-current" type="button" aria-label="Submit">      
         <svg class="w-full h-full"><use xlink:href="#search" /></svg>
       </button>

--- a/views/partials/data-search-results.njk
+++ b/views/partials/data-search-results.njk
@@ -3,7 +3,7 @@
   <li class="mt-10">
     <div>
       <h3 class="text-2xl font-semibold">
-        <a class="text-primary" href="/{{ package.organization.name or 'dataset' }}/{{ package.name }}">{{ package.title or package.name }}</a>
+        <a class="text-primary hover:underline" href="/{{ package.organization.name or 'dataset' }}/{{ package.name }}">{{ package.title or package.name }}</a>
       </h3>
       <a href="/{{ package.organization.name or 'dataset' }}" class="text-gray-500 block mt-1">
         {{ package.organization.title or package.organization.name or 'dataset' }}

--- a/views/post.html
+++ b/views/post.html
@@ -9,10 +9,10 @@
   <nav class="breadcrumb" aria-label="breadcrumb">
     <ol>
       <li class="breadcrumb_item">
-        <a class="breadcrumb_link" href="/">{{__('Home')}}</a>
+        <a class="breadcrumb_link hover:underline" href="/">{{__('Home')}}</a>
       </li>
       <li class="breadcrumb_item">
-        <a class="breadcrumb_link" href="/blog">{{__('Blog')}}</a>
+        <a class="breadcrumb_link hover:underline" href="/blog">{{__('Blog')}}</a>
       </li>
       <li class="breadcrumb_item">
         <a class="breadcrumb_link" href="/blog/{{slug}}" aria-current="page">{{title | safe}}</a>
@@ -25,7 +25,7 @@
 
   <main class="mb-gutter lg:mb-0 lg:w-2/3 lg:mr-gutter">
     <!-- featured image -->
-    <img class="w-full" src="{{image or '/static/img/placeholder.svg'}}" />
+    <img class="w-full" alt="{{ alt or title }}" src="{{image or '/static/img/placeholder.svg'}}" />
 
     <h1 class="text-4xl font-semibold">{{title | safe}}</h1>
     <div class="mb-3">
@@ -54,7 +54,7 @@
     <h2 class="bg-gray-200 px-4 py-3 font-bold mb-1">{{__('Share')}}</h2>
     <ul class="text-sm">
       <li class="border-b-2 border-gray-200">
-        <a class="block px-4 py-3 text-primary" href="https://twitter.com/intent/tweet?url={{thisPageFullUrl}}&text={{title}}" target="_blank">Twitter</a>
+        <a class="block px-4 py-3 text-primary font-semibold hover:underline" aria-label="Tweet {{ title }}" href="https://twitter.com/intent/tweet?url={{thisPageFullUrl}}&text={{title}}" target="_blank">Twitter</a>
       </li>
     </ul>
     <!-- share links end -->

--- a/views/post.html
+++ b/views/post.html
@@ -25,7 +25,7 @@
 
   <main class="mb-gutter lg:mb-0 lg:w-2/3 lg:mr-gutter">
     <!-- featured image -->
-    <img class="w-full" alt="{{ alt or title }}" src="{{image or '/static/img/placeholder.svg'}}" />
+    <img class="w-full" alt="{{ imageCaption or imageAlt or title }}" src="{{image or '/static/img/placeholder.svg'}}" />
 
     <h1 class="text-4xl font-semibold">{{title | safe}}</h1>
     <div class="mb-3">

--- a/views/post.html
+++ b/views/post.html
@@ -25,7 +25,7 @@
 
   <main class="mb-gutter lg:mb-0 lg:w-2/3 lg:mr-gutter">
     <!-- featured image -->
-    <img class="w-full" alt="{{ imageCaption or imageAlt or title }}" src="{{image or '/static/img/placeholder.svg'}}" />
+    <img class="w-full" alt="{{ imageAlt or title or imageCaption }}" src="{{image or '/static/img/placeholder.svg'}}" />
 
     <h1 class="text-4xl font-semibold">{{title | safe}}</h1>
     <div class="mb-3">

--- a/views/search.html
+++ b/views/search.html
@@ -12,7 +12,7 @@
   <nav class="breadcrumb" aria-label="breadcrumb">
     <ol>
       <li class="breadcrumb_item">
-        <a class="breadcrumb_link" href="/">{{__('Home')}}</a>
+        <a class="breadcrumb_link hover:underline" href="/">{{__('Home')}}</a>
       </li>
       <li class="breadcrumb_item">
         <a class="breadcrumb_link" href="/search" aria-current="page">{{__('Search')}}</a>

--- a/views/showcase.html
+++ b/views/showcase.html
@@ -12,10 +12,10 @@
     <nav class="breadcrumb" aria-label="breadcrumb">
       <ol>
         <li class="breadcrumb_item">
-          <a class="breadcrumb_link" href="/">{{ __('Home') }}</a>
+          <a class="breadcrumb_link hover:underline" href="/">{{ __('Home') }}</a>
         </li>
         <li class="breadcrumb_item">
-          <a class="breadcrumb_link" href="/{{ owner.name }}">{{ owner.title or owner.name }}</a>
+          <a class="breadcrumb_link hover:underline" href="/{{ owner.name }}">{{ owner.title or owner.name }}</a>
         </li>
         <li class="breadcrumb_item">
           <a class="breadcrumb_link" href="/{{ owner.name }}/{{ dataset.name }}"
@@ -193,14 +193,14 @@
     <div class="lg:w-1/3 lg:ml-gutter lg:pl-10">
       <div class="">
         <h2 class="bg-gray-200 px-4 py-3 font-bold mb-4">{{ __('Organization') }}</h2>
-        <img src="{{ owner.avatar or '/static/img/org.svg' }}" class="m-4 h-24"/>
+        <img src="{{ owner.avatar or '/static/img/org.svg' }}" alt="{{ owner.title }}" class="m-4 h-24"/>
 
-        <a class="px-4 text-primary text-xl font-semibold" href="/{{ owner.name }}">{{ owner.title }}</a>
+        <a class="px-4 text-primary text-xl font-semibold hover:underline" href="/{{ owner.name }}">{{ owner.title }}</a>
 
         <p class="px-4 py-2 text-sm">
           {{ owner.description | safe | truncate(200) }}
         </p>
-        <a href="/{{ owner.name }}" class="text-primary font-bold">Læs mere</a>
+        <a href="/{{ owner.name }}" class="text-primary font-bold hover:underline">Læs mere</a>
 
         <!-- Metadata -->
         <h2 class="bg-gray-200 px-4 py-3 font-bold mt-4 mb-1">{{ __('Metadata') }}</h2>
@@ -278,7 +278,8 @@
         <h2 class="bg-gray-200 px-4 py-3 font-bold mt-4 mb-1">{{ __('Share') }}</h2>
         <ul class="text-sm">
           <li class="border-b-2 border-gray-200">
-            <a class="block px-4 py-3 text-primary hover:text-secondary"
+            <a class="block px-4 py-3 text-primary text-semibold hover:underline"
+               aria-label="Tweet {{ dataset.title or dataset.name }}"
                href="https://twitter.com/intent/tweet?url={{ thisPageFullUrl }}&text={{ dataset.title or dataset.name }}"
                target="_blank">Twitter</a>
           </li>

--- a/views/static.html
+++ b/views/static.html
@@ -9,11 +9,11 @@
   <nav class="breadcrumb" aria-label="breadcrumb">
     <ol>
       <li class="breadcrumb_item">
-        <a class="breadcrumb_link" href="/">{{__('Home')}}</a>
+        <a class="breadcrumb_link text-primary hover:underline" href="/">{{__('Home')}}</a>
       </li>
       {% if parentSlug %}
       <li class="breadcrumb_item">
-        <a class="breadcrumb_link" href="/{{parentSlug}}">{{parentSlug}}</a>
+        <a class="breadcrumb_link text-primary hover:underline" href="/{{parentSlug}}">{{parentSlug}}</a>
       </li>
       {% endif %}
       <li class="breadcrumb_item">
@@ -42,7 +42,7 @@
     <h2 class="bg-gray-200 px-4 py-3 font-bold mb-1">{{__('Share')}}</h2>
     <ul class="text-sm">
       <li class="border-b-2 border-gray-200">
-        <a class="block px-4 py-3 text-primary" href="https://twitter.com/intent/tweet?url={{thisPageFullUrl}}&text={{title}}" target="_blank">Twitter</a>
+        <a class="block px-4 py-3 text-primary font-semibold hover:underline" aria-label="Tweet {{ title }}" href="https://twitter.com/intent/tweet?url={{thisPageFullUrl}}&text={{title}}" target="_blank">Twitter</a>
       </li>
     </ul>
     <!-- share links end -->


### PR DESCRIPTION
… images, input fields, and Twitter

This adds hyperlink underlining to all hyperlinks that aren't a different color or change color on hover. Adds `aria-label` and `alt` to images (groups and blog posts), input fields, and Twitter links (Tweet, reply, favorite)

Related to https://github.com/datopian/frontend-v2/pull/187