### PR TITLE
[index.js][s]: Adds blog/ to slug for content redirects.

### DIFF
--- a/index.js
+++ b/index.js
@@ -228,6 +228,12 @@ module.exports = function (app) {
       const currentPage = parseInt(from, 10) / size + 1
       const pages = utils.pagination(currentPage, totalPages)
 
+      for (let item in result.posts){
+        if (result.posts[item].type == 'post'){
+          result.posts[item].slug = 'blog/' + result.posts[item].slug;
+        }
+      }
+
       res.render('search.html', {
         title: 'Search content',
         result,


### PR DESCRIPTION
Checks if the type of posts received in the result is 'post' instead of 'page' then prepends 'blog/' before the path mentioned in the slug.

Now all the blog search results are redirected to blog/{slug} unless the type of post is page. 