### PR TITLE
Fixes for minor UI bugs

### DIFF
--- a/index.js
+++ b/index.js
@@ -228,7 +228,7 @@ module.exports = function (app) {
       const currentPage = parseInt(from, 10) / size + 1
       const pages = utils.pagination(currentPage, totalPages)
 
-      res.render('search.html', {
+      res.render('search-content.html', {
         title: 'Search content',
         result,
         query: req.query,

--- a/views/collection.html
+++ b/views/collection.html
@@ -74,5 +74,10 @@
     filterToggle.setAttribute('aria-expanded', !expanded);
     filterTarget.setAttribute("data-expanded", !expanded);
   }
+
+  $("#field-order-by").change(function() {
+    window.location.href = window.location.origin + "/collections/{{ item.name }}?sort=" + $(this).val();
+  });
+
 </script>
 {% endblock %}

--- a/views/partials/content-search-form.njk
+++ b/views/partials/content-search-form.njk
@@ -1,0 +1,16 @@
+<!-- Form -->
+<form action="/search/content" method="GET">
+  <div class="relative mb-5">
+    <input id="search-content-input" type="text" class="border-2 border-solid border-gray-200 py-4 pl-4 pr-20 text-xl outline-none focus:border-secondary w-full" placeholder="{{__('Search website')}}" name="q" value="" autofocus>
+      <button id="search-button" class="absolute inset-y-0 right-0 w-16 px-4 text-secondary fill-current" type="button" aria-label="Submit">      
+        <svg class="w-full h-full"><use xlink:href="#search" /></svg>
+      </button>
+    </input>
+  </div>
+
+  <div class="lg:flex items-center justify-between">
+    <h1 class="text-4xl font-semibold text-primary">{{ result.count }} {{__('results found')}}</h1>
+  </div>
+
+</form>
+<!-- End of Form -->

--- a/views/partials/content-search-form.njk
+++ b/views/partials/content-search-form.njk
@@ -1,7 +1,7 @@
 <!-- Form -->
 <form action="/search/content" method="GET">
   <div class="relative mb-5">
-    <input id="search-content-input" type="text" class="border-2 border-solid border-gray-200 py-4 pl-4 pr-20 text-xl outline-none focus:border-secondary w-full" placeholder="{{__('Search website')}}" name="q" value="" autofocus>
+    <input id="search-content-input" aria-label="{{__('Search website')}}" type="text" class="border-2 border-solid border-gray-200 py-4 pl-4 pr-20 text-xl outline-none focus:border-secondary w-full" placeholder="{{__('Search website')}}" name="q" value="" autofocus>
       <button id="search-button" class="absolute inset-y-0 right-0 w-16 px-4 text-secondary fill-current" type="button" aria-label="Submit">      
         <svg class="w-full h-full"><use xlink:href="#search" /></svg>
       </button>

--- a/views/search-content.html
+++ b/views/search-content.html
@@ -1,0 +1,63 @@
+{% extends "search.html" %}
+
+
+{% block content %}
+<div class="container mx-auto p-gutter">
+  <nav class="breadcrumb" aria-label="breadcrumb">
+    <ol>
+      <li class="breadcrumb_item">
+        <a class="breadcrumb_link" href="/">{{__('Home')}}</a>
+      </li>
+      <li class="breadcrumb_item">
+        <a class="breadcrumb_link" href="/search/content" aria-current="page">{{__('Search')}}</a>
+      </li>
+    </ol>
+  </nav>
+</div>
+
+<div class="container mx-auto md:flex p-gutter">
+
+<main class="md:w-2/3">
+    {% include "./partials/content-search-form.njk" %}
+    {% include "./partials/content-search-results.njk" %}
+    {% include "./partials/data-search-pagination.njk" %}
+  </main>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+
+  var qTerm = "";
+
+  let params = new URLSearchParams(location.search);
+  let regExp = /(?:[^\s"]+|"[^"]*")+/g;
+  let qAll = params.get('q').match(regExp);
+
+  for (qPart of qAll) {
+    qTerm = (qTerm + " " + qPart).trim();
+  };
+  
+  $("#search-content-input").val(qTerm);
+
+  // capture search term changes
+  $("#search-content-input").on('input', function (event) {
+    qTerm = $(this).val();
+  });
+
+  // click on button event
+  var searchBtn = document.getElementById("search-button");
+
+  searchBtn.onclick = function(event) {
+    window.location.href = window.location.origin + "/search/content?q=" + qTerm;
+  };
+
+  // press on Enter event
+  $("#search-content-input").on('keyup', function (event) {
+    if (event.originalEvent.code === "Enter") {
+      window.location.href = window.location.origin + "/search/content?q=" + qTerm;
+    }
+  });
+
+</script>
+{% endblock %}

--- a/views/search.html
+++ b/views/search.html
@@ -68,46 +68,55 @@
   // split whole search query string in two parts: filters and term
   var q_filter = '';
   var q_term = '';
+  let qryString = '';
 
   let params = new URLSearchParams(location.search);
+
   let regExp = /(?:[^\s"]+|"[^"]*")+/g;
-  let q_all = params.get('q').match(regExp);
 
-  // remove duplicates from filters part
-  q_all = uniq(q_all);
+  if (params.get('q')){
 
-  for (q_part of q_all) {
-    if (q_part.includes(':')){
-      q_filter = (q_filter + " " + q_part).trim();
-    } else{
-      q_term = (q_term + " " + q_part).trim();
-    }
-  };
-  
-  // set input field value only to search term without filters
-  $("#search-input").val(q_term);
+    let q_all = params.get('q').match(regExp);
 
-  // capture search term changes
-  $("#search-input").on('input', function (event) {
-    q_term = $(this).val();
-  });
+    // remove duplicates from filters part
+    q_all = uniq(q_all);
 
-  // click on button event
-  var searchBtn = document.getElementById("search-button");
+    for (q_part of q_all) {
+      if (q_part.includes(':')){
+        q_filter = (q_filter + " " + q_part).trim();
+      } else{
+        q_term = (q_term + " " + q_part).trim();
+      }
+    };
 
-  searchBtn.onclick = function(event) {
-    window.location.href = window.location.origin + "/search?q=" + q_filter + " " + q_term;
-  };
+    // set input field value only to search term without filters
+    $("#search-input").val(q_term);
 
-  // press on Enter event
-  $("#search-input").on('keyup', function (event) {
-    if (event.originalEvent.code === "Enter") {
-      window.location.href = window.location.origin + "/search?q=" + q_filter + " " + q_term;
-    }
-  });
+    // capture search term changes
+    $("#search-input").on('input', function (event) {
+      q_term = $(this).val();
+    });
+
+    // click on button event
+    var searchBtn = document.getElementById("search-button");
+
+    searchBtn.onclick = function(event) {
+      qryString = (q_filter + " " + q_term).trim();
+      window.location.href = window.location.origin + "/search?q=" + qryString;
+    };
+
+    // press on Enter event
+    $("#search-input").on('keyup', function (event) {
+      if (event.originalEvent.code === "Enter") {
+        qryString = (q_filter + " " + q_term).trim();
+        window.location.href = window.location.origin + "/search?q=" + qryString;
+      }
+    });
+  }
 
   $("#field-order-by").change(function() {
-    window.location.href = window.location.origin + "/search?q=" + q_filter + " " + q_term + '&sort=' + $(this).val();
+    let searchQry = (q_filter + " " + q_term).trim();
+    window.location.href = window.location.origin + "/search?q=" + searchQry + '&sort=' + $(this).val();
   });
 
   // function removing duplicates from array

--- a/views/search.html
+++ b/views/search.html
@@ -78,9 +78,9 @@
 
   for (q_part of q_all) {
     if (q_part.includes(':')){
-      q_filter = q_filter + ' ' + q_part;
+      q_filter = (q_filter + " " + q_part).trim();
     } else{
-      q_term = q_term + q_part;
+      q_term = (q_term + " " + q_part).trim();
     }
   };
   
@@ -95,27 +95,27 @@
   // click on button event
   var searchBtn = document.getElementById("search-button");
 
+  queryStrng = (q_filter + " " + q_term).trim()
+
   searchBtn.onclick = function(event) {
-    window.location.href = window.location.origin + "/search?q=" + q_filter + " " + q_term;
+    window.location.href = window.location.origin + "/search?q=" + queryStrng;
   };
 
   // press on Enter event
   $("#search-input").on('keyup', function (event) {
     if (event.originalEvent.code === "Enter") {
-      window.location.href = window.location.origin + "/search?q=" + q_filter + " " + q_term;
+      window.location.href = window.location.origin + "/search?q=" + queryStrng;
     }
   });
 
   $("#field-order-by").change(function() {
-    window.location.href = window.location.origin + "/search?q=" + q_filter + " " + q_term + '&sort=' + $(this).val();
+    window.location.href = window.location.origin + "/search?q=" + queryStrng + '&sort=' + $(this).val();
   });
 
   // function removing duplicates from array
   function uniq(a) {
    return Array.from(new Set(a));
   };
-
-
 
 </script>
 {% endblock %}

--- a/views/search.html
+++ b/views/search.html
@@ -95,21 +95,19 @@
   // click on button event
   var searchBtn = document.getElementById("search-button");
 
-  queryStrng = (q_filter + " " + q_term).trim()
-
   searchBtn.onclick = function(event) {
-    window.location.href = window.location.origin + "/search?q=" + queryStrng;
+    window.location.href = window.location.origin + "/search?q=" + q_filter + " " + q_term;
   };
 
   // press on Enter event
   $("#search-input").on('keyup', function (event) {
     if (event.originalEvent.code === "Enter") {
-      window.location.href = window.location.origin + "/search?q=" + queryStrng;
+      window.location.href = window.location.origin + "/search?q=" + q_filter + " " + q_term;
     }
   });
 
   $("#field-order-by").change(function() {
-    window.location.href = window.location.origin + "/search?q=" + queryStrng + '&sort=' + $(this).val();
+    window.location.href = window.location.origin + "/search?q=" + q_filter + " " + q_term + '&sort=' + $(this).val();
   });
 
   // function removing duplicates from array


### PR DESCRIPTION
## Description

This PR fixes UI bugs mentioned in https://gitlab.com/datopian/core/support/-/issues/221

* Search concatenates all terms in the result e.g. "Syddjurs kommune" becomes "Syddjurskommune"
* Sort fails on group pages and dataset page
* Search should keep its focus on website or datasets

## Fix for search concatenate problem

Previously there was no space when appending `q_term` and `q_part` which removed the space from the search input.

Fixed in commit: https://github.com/datopian/frontend-oddk/commit/0d71c1d467a4d3965f4af7f63736f4d8b7879814

* Previously searching for "Syddjurs kommune" became "Syddjurskommune"
  ![Screenshot from 2020-09-30 07-08-34](https://user-images.githubusercontent.com/57398621/94635310-cc1db080-02eb-11eb-895e-005a9d9e1e37.png)
* After fix
  ![Screenshot from 2020-09-30 07-10-50](https://user-images.githubusercontent.com/57398621/94635457-1e5ed180-02ec-11eb-90de-f620bd670a48.png)

PS: The `queryStrng` variable in the above-mentioned commit was removed in a later commit as it wasn't working with filters properly.

Also fixes sort for the search results.
For example previously searching for dataset `06.44 Projektområdeudkast for NP Skjern Å` would give `11 results` but sorting them in descending order would give `395 results` as the string used in query to sort has no spaces in it. While after the fix after searching for the same dataset, sorting in descending order keeps the result to 11.

## Fix Sort fails on group pages

Sort was a part of the search function and it didn't work on group pages. Adding the sort function (`$("#field-order-by").change`) on the collections.html fixed it.

* Previously sort on group pages didn't work
  ![Screenshot from 2020-09-30 07-13-10](https://user-images.githubusercontent.com/57398621/94635643-8b726700-02ec-11eb-8177-3e9c98b35f63.png)
* After Fix
  ![Screenshot from 2020-09-30 07-12-49](https://user-images.githubusercontent.com/57398621/94635664-93caa200-02ec-11eb-85a0-7150e8839002.png)

Fixed in commit: https://github.com/datopian/frontend-oddk/commit/71f231b208c19231c699121708c74798118eb3c4

## Fix for keeping the focus on website or datasets

The search function on website search was using the same search template which is being used for dataset search which caused the focus to shift from website search to dataset search.

A separate template `search-content.html` for searching blog/website posts is added (uses `partials/content-search-form.njk`, also newly added) which keeps its focus on website search instead of shifting it to dataset search. 

Also the placeholder text for search bar on `/search/content/` page is `Søg pa hjemmeside`  instead of `Søg i dataset`
![Screenshot from 2020-09-30 07-21-16](https://user-images.githubusercontent.com/57398621/94636071-937ed680-02ed-11eb-82e2-e358a1b43af0.png)

## Fix Sort fails on dataset page

Also, noticed this error can be seen in the console for dataset page.  

![Screenshot from 2020-10-30 18-50-55](https://user-images.githubusercontent.com/57398621/97720578-3f346580-1aea-11eb-9da3-4eb4a85e758d.png)

Steps to reproduce:

- Click on `Data` on the top right in navbar
- Check console log
- Also try to sort the datasets using the toggle button

This is causing the toggle button not to work when `params.get` is `null` (i.e when we click on the Data on the navbar or address is https://www.opendata.dk/search).

SEE commit https://github.com/datopian/frontend-oddk/pull/29/commits/863457cfd29c6f1275d3f1c76241ff0ffae5c3a7

This commit also fixes the unnecessary spaces in the query generated in the addressbar.