### PR TITLE
[date-format][m]: sets moment locale to Danish.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,9 @@
 const moment = require('moment')
 
+// makes date formats Danish only
+// fix this if adding other languages
+moment.locale('da')
+
 module.exports = function (app) {
   const utils = app.get('utils')
   const dms = app.get('dms')


### PR DESCRIPTION
Fixes date formatting jumping from Danish to English on page reload.