### PR TITLE
Fixes the position of pagination bar on blog page

### DIFF
--- a/views/blog.html
+++ b/views/blog.html
@@ -22,15 +22,10 @@
 
   <div class="md:w-2/3 md:mr-gutter lg:flex flex-wrap justify-around">
 
-    <div class="flex flex-wrap">
+    <div class="flex flex-wrap -mx-6">
       <!-- posts -->
       {% for post in posts %}
-      {% if loop.index0 % 2 == 0 %}
-      {% set cls = "article-preview mb-gutter pb-gutter lg:w-1/2 lg:pr-gutter" %}
-      {% else %}
-      {% set cls = "article-preview mb-gutter pb-gutter lg:w-1/2 lg:pl-gutter" %}
-      {% endif %}
-      <div class="{{cls}}">
+      <div class="article-preview mb-gutter pb-gutter lg:w-1/2 px-6">
         <a class="article-preview_image" href="/blog/{{post.slug}}">
           <img class="article-preview_img" alt="{{ post.imageAlt or post.title or post.imageCaption }}" src="{{post.image or '/static/img/placeholder.svg'}}" />
         </a>

--- a/views/blog.html
+++ b/views/blog.html
@@ -20,43 +20,46 @@
 
 <div class="container mx-auto md:flex p-gutter">
 
-  <div class="md:w-2/3 md:mr-gutter lg:flex flex-wrap">
-    <!-- posts -->
-    {% for post in posts %}
-    {% if loop.index0 % 2 == 0 %}
-    {% set cls = "article-preview mb-gutter pb-gutter lg:w-1/2 lg:pr-gutter" %}
-    {% else %}
-    {% set cls = "article-preview mb-gutter pb-gutter lg:w-1/2 lg:pl-gutter" %}
-    {% endif %}
-    <div class="{{cls}}">
-      <a class="article-preview_image" href="/blog/{{post.slug}}">
-        <img class="article-preview_img" alt="{{ post.imageAlt or post.title or post.imageCaption }}" src="{{post.image or '/static/img/placeholder.svg'}}" />
-      </a>
-      <div class="article-preview_text">
-        <h1 class="article-preview_heading">
-          <a class="article-preview_heading-link hover:underline" href="/blog/{{post.slug}}">{{post.title | safe}}</a>
-        </h1>
-        <div class="mb-3">
-          <ul>
-            {% for category in post.categories %}
-            <li>
-              <a href="/blog?category={{category}}" class="inline px-3 py-1 text-xs text-white rounded mr-3 mb-3 bg-secondary" title="category">
-                {{ category }}
-              </a>
-            </li>
-            {% endfor %}
-          </ul>
-        </div>
-        <time class="article-preview_date">{{post.published}}</time>
-        <div class="article-preview_content">
-          {{ post.content | striptags | truncate(200) | safe }}
-          <p><a class="text-secondary hover:underline" href="/blog/{{post.slug}}">{{ __('Read full article') }}</a>
-            <p>
+  <div class="md:w-2/3 md:mr-gutter lg:flex flex-wrap justify-around">
+
+    <div class="flex flex-wrap">
+      <!-- posts -->
+      {% for post in posts %}
+      {% if loop.index0 % 2 == 0 %}
+      {% set cls = "article-preview mb-gutter pb-gutter lg:w-1/2 lg:pr-gutter" %}
+      {% else %}
+      {% set cls = "article-preview mb-gutter pb-gutter lg:w-1/2 lg:pl-gutter" %}
+      {% endif %}
+      <div class="{{cls}}">
+        <a class="article-preview_image" href="/blog/{{post.slug}}">
+          <img class="article-preview_img" alt="{{ post.imageAlt or post.title or post.imageCaption }}" src="{{post.image or '/static/img/placeholder.svg'}}" />
+        </a>
+        <div class="article-preview_text">
+          <h1 class="article-preview_heading">
+            <a class="article-preview_heading-link hover:underline" href="/blog/{{post.slug}}">{{post.title | safe}}</a>
+          </h1>
+          <div class="mb-3">
+            <ul>
+              {% for category in post.categories %}
+              <li>
+                <a href="/blog?category={{category}}" class="inline px-3 py-1 text-xs text-white rounded mr-3 mb-3 bg-secondary" title="category">
+                  {{ category }}
+                </a>
+              </li>
+              {% endfor %}
+            </ul>
+          </div>
+          <time class="article-preview_date">{{post.published}}</time>
+          <div class="article-preview_content">
+            {{ post.content | striptags | truncate(200) | safe }}
+            <p><a class="text-secondary hover:underline" href="/blog/{{post.slug}}">{{ __('Read full article') }}</a>
+              <p>
+          </div>
         </div>
       </div>
-    </div>
 
-    {% endfor %}
+      {% endfor %}
+    </div>
 
     {% if found > 10 %}
     <nav aria-label="Datasets" class="mt-gutter pt-gutter text-sm">


### PR DESCRIPTION
Related issue: https://gitlab.com/datopian/core/support/-/issues/221#note_444039788

## Problem

Navbar is out of place on production site. It is added to next to the last blog div instead of the bottom of the page.
![Screenshot from 2020-11-16 19-42-41](https://user-images.githubusercontent.com/57398621/99265811-ef70d080-2843-11eb-8dd1-764a78719318.png)

## Fix

Added the posts into a separate div and used `justify-around` to move the navbar to the center of the div.
Now the page looks like this
![image](https://user-images.githubusercontent.com/57398621/99266059-3068e500-2844-11eb-960f-783254e5ccd8.png)

**Fullpage**
![image](https://user-images.githubusercontent.com/57398621/99267415-bb96aa80-2845-11eb-8c3d-e04c2d21714f.png)



@EvgeniiaVak I played around with it for a while and applied a couple of different approaches too but wasn't able to get the exact same results as we have on prod by using any other approach (e.g lost padding, content got stretched, etc). Wasn't able to add space between the blogposts any other way while keeping it as close to the page on production.

For example
By removing the `if` statement

```
<div class="md:w-2/3 md:mr-gutter lg:flex flex-wrap">
    <!-- posts -->
    <div class="flex flex-wrap justify-content">
    {% for post in posts %}
    <div class="article-preview mb-gutter pb-gutter lg:w-1/2 lg:pr-gutter">
      <a class="article-preview_image" href="/blog/{{post.slug}}">
        <img class="article-preview_img" alt="{{ post.imageAlt or post.title or post.imageCaption }}" src="{{post.image or '/static/img/placeholder.svg'}}" />
      </a>
```
Got extra padding on the right and blog items moved closer to each other.
![](https://i.imgur.com/ozlIYJd.png)
![](https://i.imgur.com/pLIFZhd.png)

Tried a couple of different approaches to but no luck.
