### PR TITLE
Fixes minor UI bugs

### DIFF
--- a/views/_snippets.html
+++ b/views/_snippets.html
@@ -2,13 +2,13 @@
 
 {% macro listify(list_) -%}
   {% for item in list_ or [] %}
-    {% if item.path or item.url or item.web %}
-    <a href="{{item.path or item.url or item.web}}" class="text-secondary" title="{{item.title or item.email}}" target="_blank" aria-label="Forfatter: {{item.type or item.title or item.name}}">
-      {{item.type or item.title or item.name}}
-    </a>
-    {% elif item.email %}
+    {% if item.email %}
     <a href="mailto:{{item.email}}" class="text-secondary" title="{{item.title or item.email}}" target="_blank" aria-label="E-mail administratoren: {{item.email}}">
       {{item.title or item.name or item.email}}
+    </a>
+    {% elif item.path or item.url or item.web %}
+    <a href="{{item.path or item.url or item.web}}" class="text-secondary" title="{{item.title or item.email}}" target="_blank" aria-label="Dataejer: {{item.type or item.title or item.name}}">
+      {{item.type or item.title or item.name}}
     </a>
     {% else %}
     <span title="{{item.type or item.email}}">{{item.title or item.name}}</span>

--- a/views/showcase.html
+++ b/views/showcase.html
@@ -208,17 +208,17 @@
           <div class="px-4 py-2 text-sm">
             <dl class="info-list">
               {% if dataset.sources %}
-                <dt class="info-list_title">Forfatter</dt>
+                <dt class="info-list_title">Dataejer</dt>
                 <dd class="info-list_description">
                   {{ snippets.listify(dataset.sources) }}
                 </dd>
               {% endif %}
-              {% if dataset.author %}
-                <dt class="info-list_title">Vedligeholdes af</dt>
+              {# {% if dataset.author %}
+                <dt class="info-list_title">Dataejer</dt>
                 <dd class="info-list_description">
                   {{ snippets.listify([dataset.author]) }}
                 </dd>
-              {% endif %}
+              {% endif %}#}
               <!-- Show extras -->
               {% for item in dataset.extras %}
                 {% if item.key === 'data_quality' %}
@@ -244,7 +244,7 @@
                   {{ snippets.listify([dataset.license]) }}
                 </dd>
               {% endif %}
-              {% if dataset.groups %}
+              {# {% if dataset.groups %}
                 <dt class="info-list_title">Grupper</dt>
                 <dd class="info-list_description">
                   {% for group in dataset.groups %}
@@ -255,7 +255,7 @@
                     </p>
                   {% endfor %}
                 </dd>
-              {% endif %}
+              {% endif %} #}
               {% if dataset.update_frequency %}
                 <dt class="info-list_title">{{__('Update frequency')}}</dt>
                 <dd class="info-list_description">

--- a/views/showcase.html
+++ b/views/showcase.html
@@ -244,7 +244,7 @@
                   {{ snippets.listify([dataset.license]) }}
                 </dd>
               {% endif %}
-              {# {% if dataset.groups %}
+              {% if dataset.groups %}
                 <dt class="info-list_title">Grupper</dt>
                 <dd class="info-list_description">
                   {% for group in dataset.groups %}
@@ -255,7 +255,7 @@
                     </p>
                   {% endfor %}
                 </dd>
-              {% endif %} #}
+              {% endif %}
               {% if dataset.update_frequency %}
                 <dt class="info-list_title">{{__('Update frequency')}}</dt>
                 <dd class="info-list_description">


### PR DESCRIPTION
Fixes https://gitlab.com/datopian/core/support/-/issues/343

## Issues reported



* In the metadata section on opendata.dk
  * In the data set: https://www.opendata.dk/city-of-vejle/arbejdsulykker  The link on the Forfatter-field points to nowhere all though the data is OK. The same is not the case with for instance: https://www.opendata.dk/city-of-copenhagen/parkeringstaellinger  
   * **FIXED** in https://github.com/datopian/frontend-oddk/commit/03220a233788aad10d2c88106ac23bcec5f2aba3
* The label “Forfatter”, need to be changed to “Dataejer” to align with the latest update to the backend.
  * **FIXED** The label “Forfatter”, is now changed to “Dataejer” to align with the latest update to the backend.
* We only need the following metadata fields on the front-end:
  * Tags
  * Licens
  * Dataejer (with mailto-link)
  * Opdatering frekvens
  * Opdatering kommentarer (if not empty)
  * User defined fields …
 **FIXED** Now frontend has only the following metadata fields that are requested by the client above. Removed "Vedligeholdes af" and "Grupper" as not mentioned in the above list.

Didn't remove the code for displaying "Vedligeholdes af" and "Grupper" incase they have to be re-enabled.



