### PR TITLE
[fix][x] Search on organization page fixed

### DIFF
--- a/index.js
+++ b/index.js
@@ -194,6 +194,8 @@ module.exports = function (app) {
   })
 
   app.get('/search', async (req, res, next) => {
+    req.query.q = req.query.filter ? `${req.query.filter} ${req.query.q}` : req.query.q
+    delete req.query.filter
     try {
       let facetNameToShowAll
       for (let [key, value] of Object.entries(req.query)) {

--- a/views/partials/data-search-form.njk
+++ b/views/partials/data-search-form.njk
@@ -2,6 +2,7 @@
 <form id="search-field" role="search" action="/search" method="GET">
   <div class="relative mb-5">
     <input id="search-input" aria-label="{{__('Search datasets')}}" type="text" class="border-2 border-solid border-gray-200 py-4 pl-4 pr-20 text-xl outline-none focus:border-secondary w-full" placeholder="{{__('Search datasets')}}" name="q" value="" autofocus>
+    <input id="search-filter" type="text" hidden name="filter" value={{query.q}} >
       <button id="search-button" class="absolute inset-y-0 right-0 w-16 px-4 text-secondary fill-current" type="submit" aria-label="Submit">
         <svg class="w-full h-full"><use xlink:href="#search" /></svg>
       </button>


### PR DESCRIPTION
Description of the bug: `On the landing page of an organization
Search context is all organizations.
While on CKAN vanilla
Search context is only in the current organization.`
This PR fixes searching only packages in the current organization. 
