### PR TITLE
Filter out organizations with no datasets from the home page and /org…

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,6 +102,30 @@ module.exports = function (app) {
     next();
   });
 
+  // Override /organization route to filter out organizations with 0 datasets
+  app.get('/organization', async (req, res, next) => {
+    try {
+      const organizations = await DmsModel.getOrganizations({
+        all_fields: true,
+        include_extras: true,
+        include_dataset_count: true,
+      });
+      
+      const collections = organizations.filter(
+        (organization) => Number(organization.count ?? organization.package_count ?? 0) >= 1
+      );
+      
+      res.render('collections-home.html', {
+        title: 'Organizations',
+        description: 'CKAN Organizations are used to create, manage and publish collections of datasets. Users can have different roles within an Organization, depending on their level of authorisation to create, edit and publish.',
+        collections,
+        slug: 'organization'
+      });
+    } catch (e) {
+      next(e);
+    }
+  });
+
   app.get("/", async (req, res, next) => {
     // Set up main heading text from wp:
     const [siteInfo, collections, organizations, _events, aboutPage] =
@@ -180,7 +204,9 @@ module.exports = function (app) {
     res.locals.home_heading = siteInfo.description || "";
     // Get collections with extras
     res.locals.collections = collections;
-    res.locals.organizations = organizations;
+    res.locals.organizations = organizations.filter(
+      (organization) => Number(organization.count ?? organization.package_count ?? 0) >= 1
+    );
 
     // Get events
     res.locals.events = events;


### PR DESCRIPTION
This PR fixes https://github.com/datopian/Support-Services/issues/861

Filter organizations with zero datasets from the home page and /organization page

Add custom route handler for /organization that filters out organizations
with no datasets before rendering. This ensures only organizations with at
least one dataset are displayed on the organizations listing page.

The handler:
- Fetches all organizations with full metadata and dataset counts
- Filters to keep only organizations where count >= 1
- Renders collections-home.html with filtered results

This reduces the organization count from 25 to 18, showing only active
organizations with published datasets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a dedicated organization listing page for browsing available organizations

* **Improvements**
  * Organizations with zero datasets are now filtered out from display across the application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->