### PR TITLE
Revert back changes related to filtering Organization with no datasets.

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,30 +102,6 @@ module.exports = function (app) {
     next();
   });
 
-  // Override /organization route to filter out organizations with 0 datasets
-  app.get('/organization', async (req, res, next) => {
-    try {
-      const organizations = await DmsModel.getOrganizations({
-        all_fields: true,
-        include_extras: true,
-        include_dataset_count: true,
-      });
-      
-      const collections = organizations.filter(
-        (organization) => Number(organization.count ?? organization.package_count ?? 0) >= 1
-      );
-      
-      res.render('collections-home.html', {
-        title: 'Organizations',
-        description: 'CKAN Organizations are used to create, manage and publish collections of datasets. Users can have different roles within an Organization, depending on their level of authorisation to create, edit and publish.',
-        collections,
-        slug: 'organization'
-      });
-    } catch (e) {
-      next(e);
-    }
-  });
-
   app.get("/", async (req, res, next) => {
     // Set up main heading text from wp:
     const [siteInfo, collections, organizations, _events, aboutPage] =
@@ -204,9 +180,7 @@ module.exports = function (app) {
     res.locals.home_heading = siteInfo.description || "";
     // Get collections with extras
     res.locals.collections = collections;
-    res.locals.organizations = organizations.filter(
-      (organization) => Number(organization.count ?? organization.package_count ?? 0) >= 1
-    );
+    res.locals.organizations = organizations;
 
     // Get events
     res.locals.events = events;


### PR DESCRIPTION
Hi @mpolidori 

Please can you review this PR? We need to revert the changes from the previous PR.

This was misunderstanding with the client related to the issue https://github.com/datopian/Support-Services/issues/861.
Client actually wants to see all of the organizations including ones having no datasets.
This can be fixed by adding new config value. We should include `ckan.group_and_organization_list_max` in config values because it defaults to 25 if omitted and `organization_list` with `all_fields=true` is used in the query. https://docs.ckan.org/en/latest/api/index.html#ckan.logic.action.get.organization_list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Removed dedicated organization route and consolidated organization data handling.
  * Updated organization display to include organizations without associated datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->